### PR TITLE
Add more config variables

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -138,7 +138,7 @@ func (h *OAuth2Handler) HandleProtectedResourceMetadata(w http.ResponseWriter, r
 		"resource_documentation":                fmt.Sprintf("%s/docs", h.config.MCPURL),
 		"resource_policy_uri":                   fmt.Sprintf("%s/policy", h.config.MCPURL),
 		"resource_tos_uri":                      fmt.Sprintf("%s/tos", h.config.MCPURL),
-		"scopes_supported":                      []string{"openid", "profile", "email"},
+		"scopes_supported":                      h.config.Scopes,
 	}
 
 	// Encode and send response
@@ -243,7 +243,7 @@ func (h *OAuth2Handler) HandleOIDCDiscovery(w http.ResponseWriter, r *http.Reque
 		"token_endpoint_auth_methods_supported": []string{"none"},
 		"code_challenge_methods_supported":      []string{"plain", "S256"},
 		"subject_types_supported":               []string{"public"},
-		"scopes_supported":                      []string{"openid", "profile", "email"},
+		"scopes_supported":                      h.config.Scopes,
 	}
 
 	// Add provider-specific fields
@@ -283,7 +283,7 @@ func (h *OAuth2Handler) GetAuthorizationServerMetadata() map[string]interface{} 
 			"grant_types_supported":                 []string{"authorization_code"},
 			"token_endpoint_auth_methods_supported": []string{"none"},
 			"code_challenge_methods_supported":      []string{"plain", "S256"},
-			"scopes_supported":                      []string{"openid", "profile", "email"},
+			"scopes_supported":                      h.config.Scopes,
 		}
 
 		// Add provider-specific endpoints
@@ -315,7 +315,7 @@ func (h *OAuth2Handler) GetAuthorizationServerMetadata() map[string]interface{} 
 			"grant_types_supported":                 []string{"authorization_code"},
 			"token_endpoint_auth_methods_supported": []string{"none"},
 			"code_challenge_methods_supported":      []string{"plain", "S256"},
-			"scopes_supported":                      []string{"openid", "profile", "email"},
+			"scopes_supported":                      h.config.Scopes,
 		}
 	}
 


### PR DESCRIPTION
This PR adds support a couple of new config variables, which are useful to have available in an enterprise setting with a more complex azure setup. They are:

* `Scopes`, which defaults to the currently hardcoded values when not set
*  `SkipAudienceCheck`, which are booleans that, when true, bypass the audience check on the access token
* `ValidatorIssuer` which, if set, defines an issuer URL to use for validation, which is separate from the issuer URL used for discovery. This is needed for providers like azure that go out of spec.

I still have not added any documentation, but I can do that once I get the go-ahead. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Make OAuth2/OIDC scopes configurable via builder and environment with sensible defaults; propagate to handlers and discovery metadata.
  * Add flags to skip issuer, audience, and expiry checks via builder and environment.
  * Allow registering custom token validation callbacks.

* **Bug Fixes**
  * Token validation and discovery now consistently respect configured scopes and skip flags across flows.

* **Documentation**
  * Added guidance for configuring scopes and skip flags via environment and builder.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->