### PR TITLE
add scopes supported entry to protected resource metadata route

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -138,6 +138,7 @@ func (h *OAuth2Handler) HandleProtectedResourceMetadata(w http.ResponseWriter, r
 		"resource_documentation":                fmt.Sprintf("%s/docs", h.config.MCPURL),
 		"resource_policy_uri":                   fmt.Sprintf("%s/policy", h.config.MCPURL),
 		"resource_tos_uri":                      fmt.Sprintf("%s/tos", h.config.MCPURL),
+		"scopes_supported":                      []string{"openid", "profile", "email"},
 	}
 
 	// Encode and send response


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The metadata response now includes a "scopes_supported" field listing supported authentication scopes (openid, profile, email), improving clarity for clients about available authorization scopes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->