### PR TITLE
Support allowlist mode and fixed redirect mode simultaneously

### DIFF
--- a/config.go
+++ b/config.go
@@ -11,9 +11,10 @@ import (
 // Config holds OAuth configuration
 type Config struct {
 	// OAuth settings
-	Mode         string // "native" or "proxy"
-	Provider     string // "hmac", "okta", "google", "azure"
-	RedirectURIs string // Redirect URIs (single or comma-separated)
+	Mode             string // "native" or "proxy"
+	Provider         string // "hmac", "okta", "google", "azure"
+	RedirectURIs     string // Redirect URIs allowlist (single or comma-separated)
+	FixedRedirectURI string // Optional fixed redirect URI used for proxying callbacks
 
 	// OIDC configuration
 	Issuer       string
@@ -89,8 +90,8 @@ func (c *Config) Validate() error {
 		if c.ServerURL == "" {
 			return fmt.Errorf("proxy mode requires ServerURL")
 		}
-		if c.RedirectURIs == "" {
-			return fmt.Errorf("proxy mode requires RedirectURIs")
+		if c.RedirectURIs == "" && c.FixedRedirectURI == "" {
+			return fmt.Errorf("proxy mode requires RedirectURIs or FixedRedirectURI")
 		}
 	}
 
@@ -194,6 +195,12 @@ func (b *ConfigBuilder) WithProvider(provider string) *ConfigBuilder {
 // WithRedirectURIs sets the redirect URIs
 func (b *ConfigBuilder) WithRedirectURIs(uris string) *ConfigBuilder {
 	b.config.RedirectURIs = uris
+	return b
+}
+
+// WithFixedRedirectURI sets the fixed redirect URI used for proxying callbacks
+func (b *ConfigBuilder) WithFixedRedirectURI(uri string) *ConfigBuilder {
+	b.config.FixedRedirectURI = uri
 	return b
 }
 
@@ -319,6 +326,7 @@ func FromEnv() (*Config, error) {
 		WithMode(getEnv("OAUTH_MODE", "")).
 		WithProvider(getEnv("OAUTH_PROVIDER", "")).
 		WithRedirectURIs(getEnv("OAUTH_REDIRECT_URIS", "")).
+		WithFixedRedirectURI(getEnv("OAUTH_FIXED_REDIRECT_URI", "")).
 		WithIssuer(getEnv("OIDC_ISSUER", "")).
 		WithAudience(getEnv("OIDC_AUDIENCE", "")).
 		WithClientID(getEnv("OIDC_CLIENT_ID", "")).

--- a/metadata.go
+++ b/metadata.go
@@ -194,11 +194,16 @@ func (h *OAuth2Handler) HandleRegister(w http.ResponseWriter, r *http.Request) {
 	if redirectUris, ok := regRequest["redirect_uris"]; ok {
 		response["redirect_uris"] = redirectUris
 		h.logger.Info("OAuth2: Registration allowing client redirect URIs: %v", redirectUris)
-	} else if h.config.RedirectURIs != "" && !strings.Contains(h.config.RedirectURIs, ",") {
-		// Fallback to fixed redirect URI if no client URIs provided (single URI only)
-		trimmedURI := strings.TrimSpace(h.config.RedirectURIs)
+	} else if h.config.FixedRedirectURI != "" {
+		// Fallback to fixed redirect URI if no client URIs provided
+		trimmedURI := strings.TrimSpace(h.config.FixedRedirectURI)
 		response["redirect_uris"] = []string{trimmedURI}
 		h.logger.Info("OAuth2: Registration response using fixed redirect URI: %s", trimmedURI)
+	} else if h.config.RedirectURIs != "" && !strings.Contains(h.config.RedirectURIs, ",") {
+		// Backwards-compatible fallback: single RedirectURIs value
+		trimmedURI := strings.TrimSpace(h.config.RedirectURIs)
+		response["redirect_uris"] = []string{trimmedURI}
+		h.logger.Info("OAuth2: Registration response using single redirect URI from RedirectURIs: %s", trimmedURI)
 	}
 
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Summary
<!-- What does this PR do? -->
Right now one of two redirect URI modes is supported:
* allow list mode, where the client-provided redirect URI must be in the list registered on the given mcp server
* Fixed redirect mode, where only one redirect URI can be registered on the mcp server and the client-provided redirect URI must be a localhost that will be proxied back to

This PR redesigns the interface of the library so that both modes can be supported at the same time. 

It does so by introducing a new `FixedRedirectURI` variable, which defines a single redirect URI for fixed redirect mode.  Correspondingly, the existing `RedirectURIs` variable now only defines the valid redirect URIs for allow list mode.

If `RedirectURIs` and `FixedRedirectURI` are both set, then `RedirectURIs` takes precedence. If the client-provided redirect URI is not in `RedirectURIs` then fixed redirect mode will be tried next. 



## Changes
- Most core logic changes are in `handlers.go`, specifically in the `HandleAuthorize`, `HandleCallback` and `HandleToken` methods. 
- The new config variable is added in `config.go`
- The `handleRegister` function in `metadata.go` is also updated to properly handle the new fixed redirect mode 

## Testing
- [ ] Tests pass locally
- [ ] New tests added (if applicable)

## Related Issues
<!-- Fixes #123 -->
https://github.com/tuannvm/oauth-mcp-proxy/issues/20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add support for a fixed server-side redirect URI as an alternative to client-supplied allowlists in OAuth proxy mode.
  * Made the fixed-redirect option configurable via environment and programmatic settings so deployers can set a fixed callback URI.
  * OAuth flows now handle either allowlist or fixed-redirect strategies transparently.

* **Bug Fixes / Security**
  * Stronger validation, clearer logging, and explicit rejection paths for redirect URI handling to reduce misconfiguration and improve security.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->