### PR TITLE
fix: raise authorization code length limit from 512 to 4096

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -976,8 +976,11 @@ func (h *OAuth2Handler) isValidRedirectURI(uri string) bool {
 
 // validateOAuthParams performs basic input validation to prevent abuse
 func (h *OAuth2Handler) validateOAuthParams(r *http.Request) error {
-	// Basic length validation to prevent abuse
-	if code := r.FormValue("code"); len(code) > 512 {
+	// Basic length validation to prevent abuse.
+	// 4096 accommodates providers that issue JWT-shaped codes (Azure/Entra
+	// codes are routinely 1500-2000+ chars). The 1MB body-size limit at the
+	// token endpoint is the primary DoS guard.
+	if code := r.FormValue("code"); len(code) > 4096 {
 		return fmt.Errorf("invalid code parameter length")
 	}
 	if state := r.FormValue("state"); len(state) > 256 {

--- a/security_test.go
+++ b/security_test.go
@@ -187,7 +187,7 @@ func TestOAuthParameterValidation(t *testing.T) {
 		{
 			name: "Code too long",
 			params: map[string]string{
-				"code": strings.Repeat("a", 513), // 513 characters
+				"code": strings.Repeat("a", 4097), // 4097 characters (> 4096 limit)
 			},
 			expectError: true,
 			errorMsg:    "invalid code parameter length",


### PR DESCRIPTION
The 512-char cap on the `code` parameter in validateOAuthParams rejects authorization codes from providers that issue JWT-shaped codes. Azure Entra ID codes are routinely 1500-2000+ chars, producing a spurious "invalid code parameter length" error on token exchange.

Raise the limit to 4096, which:
- Accommodates JWT-shaped codes from all major OIDC providers
- Stays well within the 1MB body-size limit that provides the primary DoS guard at the token endpoint

Test case updated to verify rejection still triggers at > 4096.

## Summary
<!-- What does this PR do? -->

## Changes
-

## Testing
- [x] Tests pass locally
- [ ] New tests added (if applicable)

## Related Issues
<!-- Fixes #123 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased OAuth2 code parameter length limit from 512 to 4096 characters.

* **Tests**
  * Updated OAuth2 code validation tests to align with the new parameter length limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->