### PR TITLE
fix(metadata): advertise refresh_token in grant_types_supported

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -47,7 +47,7 @@ func (h *OAuth2Handler) HandleMetadata(w http.ResponseWriter, r *http.Request) {
 		"registration_endpoint":    fmt.Sprintf("%s/oauth/register", h.config.MCPURL),
 		"response_types_supported": []string{"code"},
 		"response_modes_supported": []string{"query"},
-		"grant_types_supported":    []string{"authorization_code"},
+		"grant_types_supported":    []string{"authorization_code", "refresh_token"},
 	}
 
 	// Add provider-specific metadata
@@ -247,7 +247,7 @@ func (h *OAuth2Handler) HandleOIDCDiscovery(w http.ResponseWriter, r *http.Reque
 		"registration_endpoint":                 fmt.Sprintf("%s/oauth/register", h.config.MCPURL),
 		"response_types_supported":              []string{"code"},
 		"response_modes_supported":              []string{"query"},
-		"grant_types_supported":                 []string{"authorization_code"},
+		"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
 		"token_endpoint_auth_methods_supported": []string{"none"},
 		"code_challenge_methods_supported":      []string{"plain", "S256"},
 		"subject_types_supported":               []string{"public"},
@@ -288,7 +288,7 @@ func (h *OAuth2Handler) GetAuthorizationServerMetadata() map[string]interface{} 
 			"issuer":                                h.config.Issuer, // OAuth provider issuer
 			"response_types_supported":              []string{"code"},
 			"response_modes_supported":              []string{"query"},
-			"grant_types_supported":                 []string{"authorization_code"},
+			"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
 			"token_endpoint_auth_methods_supported": []string{"none"},
 			"code_challenge_methods_supported":      []string{"plain", "S256"},
 			"scopes_supported":                      h.config.Scopes,
@@ -320,7 +320,7 @@ func (h *OAuth2Handler) GetAuthorizationServerMetadata() map[string]interface{} 
 			"jwks_uri":                              fmt.Sprintf("%s/.well-known/jwks.json", h.config.MCPURL),
 			"response_types_supported":              []string{"code"},
 			"response_modes_supported":              []string{"query"},
-			"grant_types_supported":                 []string{"authorization_code"},
+			"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
 			"token_endpoint_auth_methods_supported": []string{"none"},
 			"code_challenge_methods_supported":      []string{"plain", "S256"},
 			"scopes_supported":                      h.config.Scopes,


### PR DESCRIPTION
<!--
Title: fix(metadata): advertise refresh_token in grant_types_supported

gh pr create --repo tuannvm/oauth-mcp-proxy \
  --base main \
  --head caiopavanelli:fix/discovery-refresh-token-grant-types \
  --title "fix(metadata): advertise refresh_token in grant_types_supported" \
  --body-file tmp/upstream-pr-discovery-refresh-token.md
-->

Fixes #33

## Summary

Discovery endpoints advertised only `authorization_code` in `grant_types_supported`, while `/oauth/token` already supports `grant_type=refresh_token` (since #17) and `/oauth/register` already lists both grant types. Conformant MCP clients skip silent token renewal when metadata omits `refresh_token` (RFC 8414).

This PR aligns all authorization-server metadata responses with the token endpoint and registration behavior.

## Changes

- Add `refresh_token` to `grant_types_supported` in:
  - `HandleMetadata` (`GET /oauth/metadata`)
  - `HandleOIDCDiscovery` (`GET /.well-known/openid-configuration`)
  - `GetAuthorizationServerMetadata()` (native and proxy branches)

No changes to `/oauth/token` handlers or scope handling.

## Testing

- [x] `go test ./...` passes locally
- [ ] Manual: fetch `/.well-known/openid-configuration` (or proxy-mode MCP discovery) and confirm `grant_types_supported` includes `refresh_token`

## Related

- Closes the discovery gap left after #17 / #18
- Downstream consumers can drop fork-only metadata patches once released


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth/OIDC metadata responses now advertise support for the refresh token grant type in addition to authorization code grant type across all discovery endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->